### PR TITLE
feat: configurable path mapping with regex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@
 - `AWS_REGION`, `ECR_ACCOUNT_ID`, `ECR_REPO_PREFIX`, `ECR_CREATE_REPO` (for ECR)
 - `TARGET_REGISTRY`, `TARGET_REPO_PREFIX`, `TARGET_USERNAME`, `TARGET_PASSWORD`, `TARGET_INSECURE` (for Docker)
 - `INCLUDE_NAMESPACES`: `*` or comma list (e.g., `default,prod`)
+- Optional `pathMap` in the config file rewrites repository paths before pushing
+
+Example `config.yaml` snippet:
+
+```yaml
+pathMap:
+  - from: "group/project"
+    to: "prod/project"
+  - from: "^legacy/(.*)"
+    to: "modern/$1"
+    regex: true
+```
+
+Rules are evaluated in order with the first matching entry applied. Leaving
+`pathMap` empty keeps repository paths unchanged.
 
 ## Build container
 ```bash

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/matzegebbe/doppler/internal/controllers"
 	"github.com/matzegebbe/doppler/internal/mirror"
+	"github.com/matzegebbe/doppler/pkg/util"
 )
 
 var scheme = runtime.NewScheme()
@@ -73,7 +74,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	pusher := mirror.NewPusher(cfg.Target, cfg.DryRun, cfg.Offline)
+	transformer := util.NewRepoPathTransformer(cfg.PathMap)
+	pusher := mirror.NewPusher(cfg.Target, cfg.DryRun, cfg.Offline, transformer)
 	if err := controllers.SetupAll(mgr, pusher, cfg.AllowedNS); err != nil {
 		logger.Error(err, "setup controllers failed")
 		os.Exit(1)

--- a/cmd/manager/runtime_config.go
+++ b/cmd/manager/runtime_config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/matzegebbe/doppler/internal/config"
 	"github.com/matzegebbe/doppler/internal/registry"
+	"github.com/matzegebbe/doppler/pkg/util"
 )
 
 // runtimeConfig holds all runtime configuration derived from flags, env vars and the config file.
@@ -17,6 +18,7 @@ type runtimeConfig struct {
 	Target    registry.Target
 	DryRun    bool
 	Offline   bool
+	PathMap   []util.PathMapping
 }
 
 // loadRuntimeConfig resolves configuration from env vars and the optional config file.
@@ -147,5 +149,6 @@ func loadRuntimeConfig(ctx context.Context, dryRunFlag, offlineFlag bool) (runti
 		Target:    t,
 		DryRun:    dryRun,
 		Offline:   offline,
+		PathMap:   fileCfg.PathMap,
 	}, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"sigs.k8s.io/yaml"
+
+	"github.com/matzegebbe/doppler/pkg/util"
 )
 
 // FilePath returns default config path inside the container.
@@ -25,11 +27,12 @@ type Docker struct {
 }
 
 type Config struct {
-	TargetKind string `yaml:"targetKind"` // ecr | docker
-	ECR        ECR    `yaml:"ecr"`
-	Docker     Docker `yaml:"docker"`
-	DryRun     bool   `yaml:"dryRun"`
-	Offline    bool   `yaml:"offline"`
+	TargetKind string             `yaml:"targetKind"` // ecr | docker
+	ECR        ECR                `yaml:"ecr"`
+	Docker     Docker             `yaml:"docker"`
+	DryRun     bool               `yaml:"dryRun"`
+	Offline    bool               `yaml:"offline"`
+	PathMap    []util.PathMapping `yaml:"pathMap"`
 }
 
 func Load(path string) (Config, bool, error) {

--- a/pkg/util/path.go
+++ b/pkg/util/path.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+)
+
+// PathMapping defines a replacement rule for repository paths. When Regex is
+// set the From field is treated as a regular expression and replacement uses
+// regexp.ReplaceAllString, otherwise a simple prefix substitution is applied.
+type PathMapping struct {
+	From  string `yaml:"from"`
+	To    string `yaml:"to"`
+	Regex bool   `yaml:"regex"`
+}
+
+type compiledMapping struct {
+	PathMapping
+	re *regexp.Regexp
+}
+
+// NewRepoPathTransformer returns a function that applies the given path
+// mappings and then cleans the result for use in target registries. The first
+// matching rule wins.
+func NewRepoPathTransformer(mappings []PathMapping) func(string) string {
+	compiled := make([]compiledMapping, 0, len(mappings))
+	for _, m := range mappings {
+		cm := compiledMapping{PathMapping: m}
+		if m.Regex {
+			if r, err := regexp.Compile(m.From); err == nil {
+				cm.re = r
+			} else {
+				// skip invalid regex rules
+				continue
+			}
+		}
+		compiled = append(compiled, cm)
+	}
+	return func(p string) string {
+		for _, m := range compiled {
+			if m.Regex {
+				if m.re.MatchString(p) {
+					p = m.re.ReplaceAllString(p, m.To)
+					break
+				}
+				continue
+			}
+			if strings.HasPrefix(p, m.From) {
+				p = strings.TrimPrefix(p, m.From)
+				if m.To != "" {
+					p = strings.TrimSuffix(m.To, "/") + "/" + p
+				}
+				break
+			}
+		}
+		return CleanRepoName(p)
+	}
+}

--- a/pkg/util/path_test.go
+++ b/pkg/util/path_test.go
@@ -1,0 +1,18 @@
+package util
+
+import "testing"
+
+func TestNewRepoPathTransformer(t *testing.T) {
+	mappings := []PathMapping{
+		{From: "old/", To: "new/"},
+		{From: "^legacy/(.*)", To: "modern/$1", Regex: true},
+	}
+	transform := NewRepoPathTransformer(mappings)
+
+	if got := transform("old/repo"); got != "new/repo" {
+		t.Fatalf("prefix mapping failed: got %q", got)
+	}
+	if got := transform("legacy/service"); got != "modern/service" {
+		t.Fatalf("regex mapping failed: got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- enable optional `pathMap` rules for repository path rewrites
- add regex-aware `PathMapping` transformer and integrate with pusher
- document path mapping configuration and examples

## Testing
- `go test ./...` *(hangs: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68b4498d210483289ff5b24a2d829fc2