### PR TITLE
Add debug toggle for saw log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Do **not** use it in production environments.
 
 - Watches **Deployments**, **StatefulSets**, **Jobs**, **CronJobs**, and **Pods**
 - Mirrors container images to **AWS ECR** (via AWS SDK v2 + IRSA) or a **generic Docker registry**
-- Optional namespace filter via `INCLUDE_NAMESPACES` (e.g., `"default,prod"` or `"*"` for all)
+- Optional namespace filter via `includeNamespaces` in the config file or `INCLUDE_NAMESPACES` env (e.g., `"default,prod"` or `"*"` for all)
+- Optional push throttling via `pushInterval` in the config file or `PUSH_INTERVAL` env (e.g., `1m`)
 
 ## Why Does This Project Exist?
 
@@ -38,11 +39,20 @@ Additionally, we explicitly want a solution **not using admission webhooks**. In
 - `AWS_REGION`, `ECR_ACCOUNT_ID`, `ECR_REPO_PREFIX`, `ECR_CREATE_REPO` (for ECR)
 - `TARGET_REGISTRY`, `TARGET_REPO_PREFIX`, `TARGET_USERNAME`, `TARGET_PASSWORD`, `TARGET_INSECURE` (for Docker)
 - `INCLUDE_NAMESPACES`: `*` or comma-separated list (e.g., `default,prod`)
+- `PUSH_INTERVAL`/`PUSH_INTERVALL`: throttle pushes per image (e.g., `1m`, `30s`)
+- `DEBUG`: emit debug-level controller logs (e.g., `true` to surface "saw" messages)
+- `LOG_LEVEL`: override controller-runtime log level (e.g., `debug`, `info`, `warn`, or numeric verbosity like `2`)
 - Optional `pathMap` in the config file rewrites repository paths before pushing
 
 ### Example `config.yaml` Snippet
 
 ```yaml
+debug: true
+logLevel: debug
+includeNamespaces:
+  - default
+  - prod
+pushInterval: 1m
 pathMap:
   - from: "group/project"
     to: "prod/project"
@@ -73,3 +83,19 @@ Enable dry run mode by either:
 
 - Passing the `--dry-run` flag to the binary
 - Setting `dryRun: true` in your config file
+
+### Evicting the Push Cache
+
+k8s-copycat keeps track of recently mirrored digests to avoid repeated pushes. When
+running in `dryRun` mode, the digest is no longer cached so you can flip the flag
+off without restarting the controller. If you were running an older version (or
+just want to force a re-push), you can clear the in-memory cache via the metrics
+server:
+
+- Inspect cached entries: `curl http://localhost:8080/admin/cache`
+- Evict the entire cache: `curl -X POST http://localhost:8080/admin/cache/evict`
+- Remove entries by target prefix: `curl -X POST "http://localhost:8080/admin/cache/evict?prefix=123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo"`
+
+The eviction endpoint also accepts a JSON body with `target`, `prefix`, or
+`all` to control what is removed. The remaining cache contents are returned as
+JSON so you can verify the effect of the command.

--- a/cmd/manager/cache_admin.go
+++ b/cmd/manager/cache_admin.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/matzegebbe/k8s-copycat/internal/mirror"
+)
+
+type cacheAdmin interface {
+	ResetCache() []string
+	Evict(target string) bool
+	EvictPrefix(prefix string) []string
+	CacheEntries() []mirror.CacheEntry
+}
+
+func registerCacheAdminEndpoints(mgr ctrl.Manager, p mirror.Pusher) error {
+	admin, ok := p.(cacheAdmin)
+	if !ok {
+		return nil
+	}
+	log := ctrl.Log.WithName("cache-admin")
+
+	if err := mgr.AddMetricsServerExtraHandler("/admin/cache", newCacheStateHandler(admin)); err != nil {
+		return fmt.Errorf("register cache state handler: %w", err)
+	}
+	if err := mgr.AddMetricsServerExtraHandler("/admin/cache/evict", newCacheEvictHandler(admin, log)); err != nil {
+		return fmt.Errorf("register cache eviction handler: %w", err)
+	}
+	return nil
+}
+
+type evictionRequest struct {
+	Target string `json:"target"`
+	Prefix string `json:"prefix"`
+	All    bool   `json:"all"`
+}
+
+type evictionResponse struct {
+	Removed   []string            `json:"removed"`
+	Remaining int                 `json:"remaining"`
+	Entries   []mirror.CacheEntry `json:"entries"`
+}
+
+func newCacheEvictHandler(admin cacheAdmin, log logr.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		req, err := parseEvictionRequest(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		var removed []string
+		switch {
+		case req.Target != "":
+			if admin.Evict(req.Target) {
+				removed = []string{req.Target}
+			}
+		case req.Prefix != "":
+			removed = admin.EvictPrefix(req.Prefix)
+		case req.All:
+			removed = admin.ResetCache()
+		default:
+			// Default to evict everything when no selector is provided.
+			removed = admin.ResetCache()
+		}
+
+		entries := admin.CacheEntries()
+		if len(removed) > 0 {
+			log.Info("evicted push cache entries", "removed", removed, "remaining", len(entries))
+		}
+
+		respondJSON(w, http.StatusOK, evictionResponse{
+			Removed:   removed,
+			Remaining: len(entries),
+			Entries:   entries,
+		})
+	})
+}
+
+func newCacheStateHandler(admin cacheAdmin) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		entries := admin.CacheEntries()
+		respondJSON(w, http.StatusOK, struct {
+			Entries []mirror.CacheEntry `json:"entries"`
+			Count   int                 `json:"count"`
+		}{
+			Entries: entries,
+			Count:   len(entries),
+		})
+	})
+}
+
+func parseEvictionRequest(r *http.Request) (evictionRequest, error) {
+	var req evictionRequest
+	if r.Body != nil {
+		defer r.Body.Close()
+		if r.ContentLength != 0 {
+			dec := json.NewDecoder(io.LimitReader(r.Body, 1<<20))
+			dec.DisallowUnknownFields()
+			if err := dec.Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+				return req, fmt.Errorf("decode request body: %w", err)
+			}
+		}
+	}
+
+	q := r.URL.Query()
+	if target := strings.TrimSpace(q.Get("target")); target != "" {
+		req.Target = target
+	}
+	if prefix := strings.TrimSpace(q.Get("prefix")); prefix != "" {
+		req.Prefix = prefix
+	}
+	if all := strings.TrimSpace(q.Get("all")); all != "" {
+		req.All = parseBool(all)
+	}
+
+	req.Target = strings.TrimSpace(req.Target)
+	req.Prefix = strings.TrimSpace(req.Prefix)
+
+	if req.Target != "" && req.Prefix != "" {
+		return req, fmt.Errorf("specify either target or prefix, not both")
+	}
+	if req.Target == "" && req.Prefix == "" && !req.All {
+		req.All = true
+	}
+
+	return req, nil
+}
+
+func parseBool(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func respondJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if body == nil {
+		return
+	}
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		// We cannot write an additional error at this point, just log to stderr.
+		fmt.Printf("failed to encode JSON response: %v\n", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"io/fs"
 	"os"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
@@ -32,7 +33,13 @@ type Config struct {
 	Docker     Docker             `yaml:"docker"`
 	DryRun     bool               `yaml:"dryRun"`
 	Offline    bool               `yaml:"offline"`
+	Debug      bool               `yaml:"debug"`
+	LogLevel   string             `yaml:"logLevel"`
 	PathMap    []util.PathMapping `yaml:"pathMap"`
+	// IncludeNamespaces allows restricting watched namespaces via config.
+	IncludeNamespaces []string `yaml:"includeNamespaces"`
+	// PushInterval optionally throttles pushes to the target registry.
+	PushInterval time.Duration `yaml:"pushInterval"`
 }
 
 func Load(path string) (Config, bool, error) {

--- a/manifests/k8s.yaml
+++ b/manifests/k8s.yaml
@@ -86,6 +86,9 @@ spec:
             #  value: "/config/config.yaml"
             - name: INCLUDE_NAMESPACES
               value: "test"
+            # throttle pushes per image reference (e.g., 1m, 30s)
+            #- name: PUSH_INTERVAL
+            #  value: "1m"
           resources:
             requests: { cpu: 50m, memory: 64Mi }
             limits:   { cpu: 500m, memory: 256Mi }
@@ -125,6 +128,12 @@ metadata:
 data:
   config.yaml: |
     targetKind: ecr        # ecr | docker
+    debug: true            # emit debug-level controller logs
+    logLevel: debug        # debug | info | warn | error | panic | numeric verbosity
+    includeNamespaces:
+      - test
+      - other
+    pushInterval: 1m
     ecr:
       accountID: "123456789012"
       region: "eu-central-1"


### PR DESCRIPTION
## Summary
- add a `debug` configuration flag (and `DEBUG` env) that defaults the controller-runtime logger to debug level when requested
- wrap reconcilers with a debug-aware logger so the "saw" messages only emit when debug mode is enabled
- document the new debug option in the README and sample ConfigMap

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c9375bdf348328b4ebb03962c45aac