### PR TITLE
Add log level to ConfigMap manifest

### DIFF
--- a/manifests/k8s.yaml
+++ b/manifests/k8s.yaml
@@ -125,6 +125,7 @@ metadata:
 data:
   config.yaml: |
     targetKind: ecr        # ecr | docker
+    logLevel: info         # debug | info | warn | error | dpanic | panic | fatal
     ecr:
       accountID: "123456789012"
       region: "eu-central-1"


### PR DESCRIPTION
## Summary
- expose the zap log level configuration in the example ConfigMap manifest

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c967e872bc8328a12a36406c75deaa