### PR TITLE
Support includeNamespaces from config file

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	LogLevel            string               `yaml:"logLevel"`
 	ECR                 ECR                  `yaml:"ecr"`
 	Docker              Docker               `yaml:"docker"`
+	IncludeNamespaces   []string             `yaml:"includeNamespaces"`
 	DryRun              bool                 `yaml:"dryRun"`
 	RequestTimeout      string               `yaml:"requestTimeout"`
 	RegistryCredentials []RegistryCredential `yaml:"registryCredentials"`


### PR DESCRIPTION
## Summary
- add `includeNamespaces` to the runtime configuration loaded from the config file
- reuse common sanitisation logic for namespaces from env vars and configuration

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc0e07a62083288e1bd3ddfd709fed