### PR TITLE
Support templated repo prefixes for unique targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Additionally, we explicitly want a solution **not using admission webhooks**. In
 - `REGISTRY_REQUEST_TIMEOUT`: override the timeout for individual pull/push operations (default `2m`)
 - Optional `pathMap` in the config file rewrites repository paths before pushing
 
+### Repository prefix templating
+
+When a `repoPrefix` is configured (via config file or the corresponding
+environment variables), the value can include placeholders that are replaced at
+runtime. The following tokens are supported:
+
+- `$namespace` — Namespace of the workload or pod referencing the image
+- `$podname` — Name of the owning resource (or pod when available)
+- `$container_name` — Name of the container that uses the image
+
+For example, setting `repoPrefix: "$namespace/$podname"` ensures that the
+resulting target repositories are unique across namespaces, even when multiple
+workloads reference the same source image.
+
 ### Applying an ECR lifecycle policy
 
 You can provide an [ECR lifecycle policy](https://docs.aws.amazon.com/AmazonECR/latest/userguide/lifecycle_policy_examples.html)

--- a/internal/mirror/pusher_test.go
+++ b/internal/mirror/pusher_test.go
@@ -1,0 +1,69 @@
+package mirror
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matzegebbe/k8s-copycat/pkg/util"
+)
+
+type fakeTarget struct {
+	prefix   string
+	insecure bool
+}
+
+func (f fakeTarget) Registry() string                                    { return "example.com" }
+func (f fakeTarget) RepoPrefix() string                                  { return f.prefix }
+func (f fakeTarget) EnsureRepository(_ context.Context, _ string) error  { return nil }
+func (f fakeTarget) BasicAuth(_ context.Context) (string, string, error) { return "", "", nil }
+func (f fakeTarget) Insecure() bool                                      { return f.insecure }
+
+func TestResolveRepoPathWithMetadata(t *testing.T) {
+	p := &pusher{
+		target:    fakeTarget{prefix: "$namespace/$podname/$container_name"},
+		transform: util.CleanRepoName,
+	}
+
+	repo := p.resolveRepoPath("library/nginx", Metadata{Namespace: "team-a", PodName: "pod-1", ContainerName: "app"})
+	want := "team-a/pod-1/app/library/nginx"
+	if repo != want {
+		t.Fatalf("expected %q, got %q", want, repo)
+	}
+}
+
+func TestExpandRepoPrefixSkipsEmptySegments(t *testing.T) {
+	cases := []struct {
+		name string
+		pref string
+		meta Metadata
+		want string
+	}{
+		{
+			name: "all placeholders",
+			pref: "$namespace/$podname",
+			meta: Metadata{Namespace: "default"},
+			want: "default",
+		},
+		{
+			name: "static path",
+			pref: "mirror",
+			meta: Metadata{Namespace: "irrelevant"},
+			want: "mirror",
+		},
+		{
+			name: "trim spaces",
+			pref: "  $namespace / $container_name  ",
+			meta: Metadata{Namespace: "Team", ContainerName: "App"},
+			want: "Team/App",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := expandRepoPrefix(tc.pref, tc.meta)
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/util/images_test.go
+++ b/pkg/util/images_test.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestImagesFromPodSpecIncludesContainerNames(t *testing.T) {
+	spec := &corev1.PodSpec{
+		InitContainers: []corev1.Container{{
+			Name:  "init-db",
+			Image: "busybox:1",
+		}},
+		Containers: []corev1.Container{{
+			Name:  "app",
+			Image: "nginx:1",
+		}, {
+			Name:  "sidecar",
+			Image: "busybox:1",
+		}},
+		EphemeralContainers: []corev1.EphemeralContainer{{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debug",
+				Image: "alpine:3",
+			},
+		}},
+	}
+
+	images := ImagesFromPodSpec(spec)
+	if len(images) != 4 {
+		t.Fatalf("expected 4 images, got %d", len(images))
+	}
+
+	expected := []PodImage{
+		{ContainerName: "init-db", Image: "busybox:1"},
+		{ContainerName: "app", Image: "nginx:1"},
+		{ContainerName: "sidecar", Image: "busybox:1"},
+		{ContainerName: "debug", Image: "alpine:3"},
+	}
+
+	for i, want := range expected {
+		if images[i] != want {
+			t.Fatalf("index %d: expected %+v, got %+v", i, want, images[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- allow `repoPrefix` strings to include placeholders like `$namespace`, `$podname`, and `$container_name` by passing workload metadata into the pusher
- capture container names when collecting images so prefix templates can resolve correctly and ensure controllers pass the metadata along
- document the templating feature and cover it with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cdc07c408c83288dea2b1f83cfa38d