### PR TITLE
Add skip configuration for namespaces and workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Additionally, we explicitly want a solution **not using admission webhooks**. In
 - `AWS_REGION`, `ECR_ACCOUNT_ID`, `ECR_REPO_PREFIX`, `ECR_CREATE_REPO` (for ECR)
 - `TARGET_REGISTRY`, `TARGET_REPO_PREFIX`, `TARGET_USERNAME`, `TARGET_PASSWORD`, `TARGET_INSECURE` (for Docker)
 - `INCLUDE_NAMESPACES`: `*` or comma-separated list (e.g., `default,prod`)
+- `SKIP_NAMESPACES`: comma-separated namespaces that should be ignored entirely
+- `SKIP_DEPLOYMENTS`, `SKIP_STATEFULSETS`, `SKIP_JOBS`, `SKIP_CRONJOBS`, `SKIP_PODS`: comma-separated workload names to ignore
 - `REGISTRY_REQUEST_TIMEOUT`: override the timeout for individual pull/push operations (default `2m`)
 - Optional `pathMap` in the config file rewrites repository paths before pushing
 
@@ -88,6 +90,10 @@ pathMap:
   - from: "^legacy/(.*)"
     to: "modern/$1"
     regex: true
+skipNamespaces: ["kube-system"]
+skipNames:
+  deployments: ["copycat"]
+  cronJobs: ["nightly"]
 ```
 
 Rules are evaluated in order, with the first matching entry applied. Leaving

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -98,10 +98,10 @@ func main() {
 
 	transformer := util.NewRepoPathTransformer(cfg.PathMap)
 	pusher := mirror.NewPusher(cfg.Target, cfg.DryRun, transformer, logger.WithName("mirror"), cfg.Keychain, cfg.RequestTimeout)
-	if err := controllers.SetupAll(mgr, pusher, cfg.AllowedNS); err != nil {
-		logger.Error(err, "setup controllers failed 🙀")
-		os.Exit(1)
-	}
+        if err := controllers.SetupAll(mgr, pusher, cfg.AllowedNS, cfg.SkipCfg); err != nil {
+                logger.Error(err, "setup controllers failed 🙀")
+                os.Exit(1)
+        }
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		logger.Error(err, "healthz failed 🙀")

--- a/cmd/manager/runtime_config_test.go
+++ b/cmd/manager/runtime_config_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveAllowedNamespaces(t *testing.T) {
+	t.Parallel()
+
+	got := resolveAllowedNamespaces("", nil)
+	if !reflect.DeepEqual(got, []string{"*"}) {
+		t.Fatalf("expected default wildcard, got %v", got)
+	}
+
+	got = resolveAllowedNamespaces("default, prod", nil)
+	if !reflect.DeepEqual(got, []string{"default", "prod"}) {
+		t.Fatalf("unexpected env parsing result: %v", got)
+	}
+
+	got = resolveAllowedNamespaces("   ", []string{"test", "prod"})
+	if !reflect.DeepEqual(got, []string{"test", "prod"}) {
+		t.Fatalf("expected fallback to config values, got %v", got)
+	}
+}
+
+func TestResolveList(t *testing.T) {
+	t.Parallel()
+
+	got := resolveList("alpha , beta", []string{"gamma"})
+	if !reflect.DeepEqual(got, []string{"alpha", "beta"}) {
+		t.Fatalf("unexpected env list result: %v", got)
+	}
+
+	got = resolveList("", []string{"gamma", "delta"})
+	if !reflect.DeepEqual(got, []string{"gamma", "delta"}) {
+		t.Fatalf("expected fallback to config list, got %v", got)
+	}
+
+	got = resolveList("", []string{" ", "", "delta"})
+	if !reflect.DeepEqual(got, []string{"delta"}) {
+		t.Fatalf("expected sanitize to drop blanks, got %v", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,11 +13,11 @@ import (
 const FilePath = "/config/config.yaml"
 
 type ECR struct {
-        AccountID  string `yaml:"accountID"`
-        Region     string `yaml:"region"`
-        RepoPrefix string `yaml:"repoPrefix"`
-        CreateRepo *bool  `yaml:"createRepo"`
-        LifecyclePolicy string `yaml:"lifecyclePolicy"`
+	AccountID       string `yaml:"accountID"`
+	Region          string `yaml:"region"`
+	RepoPrefix      string `yaml:"repoPrefix"`
+	CreateRepo      *bool  `yaml:"createRepo"`
+	LifecyclePolicy string `yaml:"lifecyclePolicy"`
 }
 
 type Docker struct {
@@ -47,10 +47,21 @@ type Config struct {
 	ECR                 ECR                  `yaml:"ecr"`
 	Docker              Docker               `yaml:"docker"`
 	IncludeNamespaces   []string             `yaml:"includeNamespaces"`
+	SkipNamespaces      []string             `yaml:"skipNamespaces"`
+	SkipNames           ResourceSkipNames    `yaml:"skipNames"`
 	DryRun              bool                 `yaml:"dryRun"`
 	RequestTimeout      string               `yaml:"requestTimeout"`
 	RegistryCredentials []RegistryCredential `yaml:"registryCredentials"`
 	PathMap             []util.PathMapping   `yaml:"pathMap"`
+}
+
+// ResourceSkipNames declares resource names that should be ignored by copycat.
+type ResourceSkipNames struct {
+	Deployments  []string `yaml:"deployments"`
+	StatefulSets []string `yaml:"statefulSets"`
+	Jobs         []string `yaml:"jobs"`
+	CronJobs     []string `yaml:"cronJobs"`
+	Pods         []string `yaml:"pods"`
 }
 
 func Load(path string) (Config, bool, error) {

--- a/internal/controllers/controllers_test.go
+++ b/internal/controllers/controllers_test.go
@@ -1,0 +1,140 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNameMatcherMatches(t *testing.T) {
+	matcher := newNameMatcher([]string{"copycat", "prod/only", "dev/app"})
+	if !matcher.matches("default", "copycat") {
+		t.Fatalf("expected global match for copycat")
+	}
+	if !matcher.matches("prod", "only") {
+		t.Fatalf("expected namespace specific match for prod/only")
+	}
+	if !matcher.matches("dev", "app") {
+		t.Fatalf("expected namespace specific match for dev/app")
+	}
+	wildcard := newNameMatcher([]string{"*"})
+	if !wildcard.matches("ns", "anything") {
+		t.Fatalf("expected wildcard match when * present")
+	}
+}
+
+func TestNamespaceFiltering(t *testing.T) {
+	r := baseReconciler{
+		AllowedNamespaces: []string{"*"},
+		SkippedNamespaces: map[string]struct{}{"kube-system": {}},
+	}
+	if r.nsAllowed("kube-system") {
+		t.Fatalf("expected kube-system to be skipped")
+	}
+	if !r.nsAllowed("default") {
+		t.Fatalf("expected default to be allowed")
+	}
+
+	r = baseReconciler{
+		AllowedNamespaces: []string{"prod", "default"},
+		SkippedNamespaces: map[string]struct{}{"prod": {}},
+	}
+	if r.nsAllowed("prod") {
+		t.Fatalf("expected prod to be skipped despite allow list")
+	}
+	if !r.nsAllowed("default") {
+		t.Fatalf("expected default to be allowed from allow list")
+	}
+	if r.nsAllowed("dev") {
+		t.Fatalf("expected dev to be disallowed")
+	}
+}
+
+func TestPodReconcilerShouldSkip(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add batch scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "copycat", Namespace: "default"}}
+	replicaSet := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
+		Name:      "copycat-abc",
+		Namespace: "default",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Kind:       "Deployment",
+			Name:       "copycat",
+		}},
+	}}
+	cronJob := &batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "default"}}
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "nightly-123",
+		Namespace: "default",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: batchv1.SchemeGroupVersion.String(),
+			Kind:       "CronJob",
+			Name:       "nightly",
+		}},
+	}}
+	statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "default"}}
+
+	podFromDeployment := podWithOwner("default", "copycat-abc-def", appsv1.SchemeGroupVersion.WithKind("ReplicaSet"), "copycat-abc")
+	podFromJob := podWithOwner("default", "nightly-123-xyz", batchv1.SchemeGroupVersion.WithKind("Job"), "nightly-123")
+	podFromStatefulSet := podWithOwner("default", "db-0", appsv1.SchemeGroupVersion.WithKind("StatefulSet"), "db")
+	allowedPod := podWithOwner("default", "other-123", appsv1.SchemeGroupVersion.WithKind("ReplicaSet"), "other-123")
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		deployment, replicaSet, cronJob, job, statefulSet,
+	).Build()
+
+	reconciler := PodReconciler{baseReconciler{
+		Client:            client,
+		AllowedNamespaces: []string{"*"},
+		SkippedNamespaces: map[string]struct{}{},
+		SkipDeployments:   newNameMatcher([]string{"copycat"}),
+		SkipStatefulSets:  newNameMatcher([]string{"db"}),
+		SkipJobs:          newNameMatcher(nil),
+		SkipCronJobs:      newNameMatcher([]string{"nightly"}),
+		SkipPods:          newNameMatcher(nil),
+	}}
+
+	ctx := context.Background()
+
+	if skip, err := reconciler.shouldSkipPod(ctx, podFromDeployment); err != nil || !skip {
+		t.Fatalf("expected deployment pod to be skipped, skip=%v err=%v", skip, err)
+	}
+	if skip, err := reconciler.shouldSkipPod(ctx, podFromJob); err != nil || !skip {
+		t.Fatalf("expected cronjob pod to be skipped, skip=%v err=%v", skip, err)
+	}
+	if skip, err := reconciler.shouldSkipPod(ctx, podFromStatefulSet); err != nil || !skip {
+		t.Fatalf("expected statefulset pod to be skipped, skip=%v err=%v", skip, err)
+	}
+	if skip, err := reconciler.shouldSkipPod(ctx, allowedPod); err != nil || skip {
+		t.Fatalf("expected unrelated pod not to be skipped, skip=%v err=%v", skip, err)
+	}
+}
+
+func podWithOwner(namespace, name string, gvkt schema.GroupVersionKind, ownerName string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: gvkt.GroupVersion().String(),
+			Kind:       gvkt.Kind,
+			Name:       ownerName,
+		}},
+	}}
+}

--- a/manifests/k8s.yaml
+++ b/manifests/k8s.yaml
@@ -94,6 +94,18 @@ spec:
             #  value: "/config/config.yaml"
             - name: INCLUDE_NAMESPACES
               value: "test"
+            #- name: SKIP_NAMESPACES
+            #  value: "kube-system,copycat"
+            #- name: SKIP_DEPLOYMENTS
+            #  value: "copycat"
+            #- name: SKIP_STATEFULSETS
+            #  value: "redis"
+            #- name: SKIP_JOBS
+            #  value: "backup"
+            #- name: SKIP_CRONJOBS
+            #  value: "nightly"
+            #- name: SKIP_PODS
+            #  value: "custom-pod"
           resources:
             requests: { cpu: 50m, memory: 64Mi }
             limits:   { cpu: 500m, memory: 256Mi }
@@ -134,6 +146,13 @@ data:
     logLevel: debug         # debug | info | warn | error | dpanic | panic | fatal
     dryRun: false
     includeNamespaces: ["test"]
+    # skipNamespaces: ["kube-system"]
+    # skipNames:
+    #   deployments: ["copycat"]
+    #   statefulSets: ["redis"]
+    #   jobs: ["backup"]
+    #   cronJobs: ["nightly"]
+    #   pods: ["custom-pod"]
     requestTimeout: 2m
     #ecr:
     #  accountID: "123456789012"


### PR DESCRIPTION
## Summary
- add configuration for skipping namespaces and workload names via env vars or config file
- update controllers to honor skip lists, including pods created by skipped owners
- document the new options and add unit tests for runtime parsing and skip logic

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0e4f5ab008328bef55186820de44e