### PR TITLE
Update README overview text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Do **not** use it in production environments.
 
 ![k8s-copycat logo](k8s-copycat-logo.png)
 
-- Watches **Deployments**, **StatefulSets**, **Jobs**, **CronJobs**, and **Pods**
-- Mirrors container images to **AWS ECR** (via AWS SDK v2 + IRSA) or a **generic Docker registry**
-- Optional namespace filter via `INCLUDE_NAMESPACES` (e.g., `"default,prod"` or `"*"` for all)
+k8s-copycat monitors your cluster’s **Deployments**, **StatefulSets**, **Jobs**, **CronJobs**, and **Pods** to mirror their container images into **AWS ECR** or any other Docker-compatible registry, with optional namespace filtering via `INCLUDE_NAMESPACES` when you need to scope the sync.
 
 ## Why Does This Project Exist?
 


### PR DESCRIPTION
## Summary
- replace the introductory bullet list with a concise paragraph describing how k8s-copycat tracks Kubernetes workloads
- mention the optional INCLUDE_NAMESPACES filter while emphasizing image mirroring into ECR or other Docker registries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d422df667483288d95c31e4725ecb3