### PR TITLE
feat: make controller concurrency configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,14 @@ skipNamespaces: ["kube-system"]
 skipNames:
   deployments: ["copycat"]
   cronJobs: ["nightly"]
+maxConcurrentReconciles: 4
 ```
 
 Rules are evaluated in order, with the first matching entry applied. Leaving
 `pathMap` empty keeps repository paths unchanged.
+
+When `maxConcurrentReconciles` is omitted, copycat defaults to two workers per controller. You can also override the value at
+runtime via the `MAX_CONCURRENT_RECONCILES` environment variable.
 
 ### Configuring registry credentials
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -103,7 +103,7 @@ func main() {
 
 	transformer := util.NewRepoPathTransformer(cfg.PathMap)
 	pusher := mirror.NewPusher(cfg.Target, cfg.DryRun, transformer, logger.WithName("mirror"), cfg.Keychain, cfg.RequestTimeout, cfg.FailureCooldown)
-	if err := controllers.SetupAll(mgr, pusher, cfg.AllowedNS, cfg.SkipCfg); err != nil {
+	if err := controllers.SetupAll(mgr, pusher, cfg.AllowedNS, cfg.SkipCfg, cfg.MaxConcurrentReconciles); err != nil {
 		logger.Error(err, "setup controllers failed 🙀")
 		os.Exit(1)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,18 +42,19 @@ type RegistryCredential struct {
 }
 
 type Config struct {
-	TargetKind             string               `yaml:"targetKind"` // ecr | docker
-	LogLevel               string               `yaml:"logLevel"`
-	ECR                    ECR                  `yaml:"ecr"`
-	Docker                 Docker               `yaml:"docker"`
-	IncludeNamespaces      []string             `yaml:"includeNamespaces"`
-	SkipNamespaces         []string             `yaml:"skipNamespaces"`
-	SkipNames              ResourceSkipNames    `yaml:"skipNames"`
-	DryRun                 bool                 `yaml:"dryRun"`
-	RequestTimeout         string               `yaml:"requestTimeout"`
-	FailureCooldownMinutes *int                 `yaml:"failureCooldownMinutes"`
-	RegistryCredentials    []RegistryCredential `yaml:"registryCredentials"`
-	PathMap                []util.PathMapping   `yaml:"pathMap"`
+	TargetKind              string               `yaml:"targetKind"` // ecr | docker
+	LogLevel                string               `yaml:"logLevel"`
+	ECR                     ECR                  `yaml:"ecr"`
+	Docker                  Docker               `yaml:"docker"`
+	IncludeNamespaces       []string             `yaml:"includeNamespaces"`
+	SkipNamespaces          []string             `yaml:"skipNamespaces"`
+	SkipNames               ResourceSkipNames    `yaml:"skipNames"`
+	DryRun                  bool                 `yaml:"dryRun"`
+	RequestTimeout          string               `yaml:"requestTimeout"`
+	FailureCooldownMinutes  *int                 `yaml:"failureCooldownMinutes"`
+	MaxConcurrentReconciles *int                 `yaml:"maxConcurrentReconciles"`
+	RegistryCredentials     []RegistryCredential `yaml:"registryCredentials"`
+	PathMap                 []util.PathMapping   `yaml:"pathMap"`
 }
 
 // ResourceSkipNames declares resource names that should be ignored by copycat.


### PR DESCRIPTION
## Summary
- allow configuring controller concurrency via config file and MAX_CONCURRENT_RECONCILES env var
- pass resolved concurrency into all reconcilers during setup
- document the new configuration option in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d422c2bd14832886b9453ab5796388