### PR TITLE
feat: add cooldown reset endpoint and namespace validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Additionally, we explicitly want a solution **not using admission webhooks**. In
 - `INCLUDE_NAMESPACES`: `*` or comma-separated list (e.g., `default,prod`)
 - `SKIP_NAMESPACES`: comma-separated namespaces that should be ignored entirely
 - `SKIP_DEPLOYMENTS`, `SKIP_STATEFULSETS`, `SKIP_JOBS`, `SKIP_CRONJOBS`, `SKIP_PODS`: comma-separated workload names to ignore
-- `REGISTRY_REQUEST_TIMEOUT`: override the timeout for individual pull/push operations (default `2m`)
+- `REGISTRY_REQUEST_TIMEOUT`: override the timeout (in seconds) for individual pull/push operations (default `120`)
 - `FAILURE_COOLDOWN_MINUTES`: minutes to wait before retrying a failed mirror operation (default `1440`, set to `0` to disable)
 - `METRICS_ADDR`: bind address for the Prometheus metrics endpoint (default `:8080`)
 - Optional `pathMap` in the config file rewrites repository paths before pushing
@@ -110,7 +110,7 @@ useful for authenticating against Docker Hub or other registries even when
 mirroring into a different target such as ECR.
 
 ```yaml
-requestTimeout: 2m
+requestTimeout: 120          # seconds; set to 0 to disable per-request deadlines
 failureCooldownMinutes: 60   # retry failed pushes after one hour; set to 0 to disable the cooldown
 registryCredentials:
   - registry: registry-1.docker.io
@@ -119,6 +119,8 @@ registryCredentials:
   - registry: ghcr.io
     tokenEnv: GHCR_TOKEN
 ```
+
+`requestTimeout` limits how long copycat waits for each registry pull and push. When the timeout elapses, the current operation is aborted so the controller can retry later. Setting the value to `0` (or omitting it) disables the per-request deadline and lets copycat rely on the underlying client timeouts.
 
 When `failureCooldownMinutes` is set to `0`, copycat retries failed pushes immediately without recording cooldown state. Omit the field to use the default of 24 hours.
 

--- a/cmd/manager/http_handlers.go
+++ b/cmd/manager/http_handlers.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+type cooldownResetter interface {
+	ResetCooldown() (cleared int, cooldownEnabled bool)
+}
+
+type cooldownResetResponse struct {
+	Reset          bool   `json:"reset"`
+	ClearedTargets int    `json:"clearedTargets"`
+	Message        string `json:"message"`
+}
+
+type cooldownHandler struct {
+	log      logr.Logger
+	mu       sync.RWMutex
+	resetter cooldownResetter
+}
+
+func newCooldownHandler(log logr.Logger) *cooldownHandler {
+	return &cooldownHandler{log: log}
+}
+
+func (h *cooldownHandler) SetResetter(resetter cooldownResetter) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.resetter = resetter
+}
+
+func (h *cooldownHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.RLock()
+	resetter := h.resetter
+	h.mu.RUnlock()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if resetter == nil {
+		resp := cooldownResetResponse{Message: "cooldown reset service not ready"}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			h.log.Error(err, "encode cooldown reset response")
+		}
+		return
+	}
+
+	cleared, enabled := resetter.ResetCooldown()
+
+	response := cooldownResetResponse{
+		Reset:          enabled && cleared > 0,
+		ClearedTargets: cleared,
+	}
+
+	if !enabled {
+		response.Message = "failure cooldown disabled"
+	} else if cleared == 0 {
+		response.Message = "no cooldown entries to reset"
+	} else {
+		response.Message = "failure cooldown reset"
+	}
+
+	h.log.Info("processed cooldown reset request", "method", r.Method, "clearedTargets", cleared, "cooldownEnabled", enabled)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		h.log.Error(err, "encode cooldown reset response")
+	}
+}

--- a/cmd/manager/http_handlers_test.go
+++ b/cmd/manager/http_handlers_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+)
+
+type fakeResetter struct {
+	cleared int
+	enabled bool
+}
+
+func (f fakeResetter) ResetCooldown() (int, bool) {
+	return f.cleared, f.enabled
+}
+
+func TestCooldownResetHandler(t *testing.T) {
+	handler := newCooldownHandler(testr.New(t))
+	handler.SetResetter(fakeResetter{cleared: 3, enabled: true})
+
+	req := httptest.NewRequest(http.MethodPost, "/reset-cooldown", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("unexpected content type: %s", got)
+	}
+
+	var resp cooldownResetResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Reset || resp.ClearedTargets != 3 || resp.Message != "failure cooldown reset" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestCooldownResetHandlerDisabled(t *testing.T) {
+	handler := newCooldownHandler(testr.New(t))
+	handler.SetResetter(fakeResetter{cleared: 0, enabled: false})
+
+	req := httptest.NewRequest(http.MethodGet, "/reset-cooldown", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	var resp cooldownResetResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Reset || resp.ClearedTargets != 0 || resp.Message != "failure cooldown disabled" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestCooldownResetHandlerNotReady(t *testing.T) {
+	handler := newCooldownHandler(testr.New(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/reset-cooldown", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	var resp cooldownResetResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Reset || resp.ClearedTargets != 0 || resp.Message != "cooldown reset service not ready" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}

--- a/cmd/manager/namespaces.go
+++ b/cmd/manager/namespaces.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func validateAndExpandNamespaces(ctx context.Context, log logr.Logger, client kubernetes.Interface, selections []string) ([]string, error) {
+	if len(selections) == 0 {
+		return []string{"*"}, nil
+	}
+
+	normalized := make([]string, 0, len(selections))
+	for _, raw := range selections {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		normalized = append(normalized, trimmed)
+		if trimmed == "*" {
+			return []string{"*"}, nil
+		}
+	}
+	if len(normalized) == 0 {
+		return []string{"*"}, nil
+	}
+
+	nsList, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list namespaces: %w", err)
+	}
+
+	existing := make([]string, 0, len(nsList.Items))
+	existingSet := make(map[string]struct{}, len(nsList.Items))
+	for _, item := range nsList.Items {
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+		existing = append(existing, name)
+		existingSet[name] = struct{}{}
+	}
+
+	results := make(map[string]struct{}, len(normalized))
+	for _, sel := range normalized {
+		if hasWildcard(sel) {
+			matches, matchErr := matchNamespacePattern(sel, existing)
+			if matchErr != nil {
+				log.Error(matchErr, "invalid namespace pattern", "pattern", sel)
+				continue
+			}
+			if len(matches) == 0 {
+				log.Info("namespace wildcard matched no namespaces", "pattern", sel)
+				continue
+			}
+			for _, name := range matches {
+				results[name] = struct{}{}
+			}
+			continue
+		}
+
+		if _, ok := existingSet[sel]; !ok {
+			log.Error(fmt.Errorf("namespace %q does not exist", sel), "configured namespace missing", "namespace", sel)
+		}
+		results[sel] = struct{}{}
+	}
+
+	expanded := make([]string, 0, len(results))
+	for name := range results {
+		expanded = append(expanded, name)
+	}
+	sort.Strings(expanded)
+	return expanded, nil
+}
+
+func hasWildcard(value string) bool {
+	return strings.ContainsAny(value, "*?[")
+}
+
+func matchNamespacePattern(pattern string, candidates []string) ([]string, error) {
+	matches := make([]string, 0)
+	for _, name := range candidates {
+		ok, err := path.Match(pattern, name)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			matches = append(matches, name)
+		}
+	}
+	sort.Strings(matches)
+	return matches, nil
+}

--- a/cmd/manager/namespaces_test.go
+++ b/cmd/manager/namespaces_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestValidateAndExpandNamespaces(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-1"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-2"}},
+	)
+
+	ctx := context.Background()
+	log := testr.New(t)
+
+	expanded, err := validateAndExpandNamespaces(ctx, log, client, []string{"default", "test-*"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"default", "test-1", "test-2"}
+	if len(expanded) != len(want) {
+		t.Fatalf("unexpected expanded length: want %d got %d", len(want), len(expanded))
+	}
+	for i, name := range want {
+		if expanded[i] != name {
+			t.Fatalf("unexpected namespace at index %d: want %s got %s", i, name, expanded[i])
+		}
+	}
+
+	expanded, err = validateAndExpandNamespaces(ctx, log, client, []string{"missing"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(expanded) != 1 || expanded[0] != "missing" {
+		t.Fatalf("expected missing namespace to be returned, got %#v", expanded)
+	}
+
+	expanded, err = validateAndExpandNamespaces(ctx, log, client, []string{"*"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(expanded) != 1 || expanded[0] != "*" {
+		t.Fatalf("expected wildcard to remain '*', got %#v", expanded)
+	}
+}
+
+func TestMatchNamespacePatternInvalid(t *testing.T) {
+	if _, err := matchNamespacePattern("test-[", []string{"test-1"}); err == nil {
+		t.Fatalf("expected error for invalid pattern")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	SkipNamespaces          []string             `yaml:"skipNamespaces"`
 	SkipNames               ResourceSkipNames    `yaml:"skipNames"`
 	DryRun                  bool                 `yaml:"dryRun"`
-	RequestTimeout          string               `yaml:"requestTimeout"`
+	RequestTimeoutSeconds   *int                 `yaml:"requestTimeout"`
 	FailureCooldownMinutes  *int                 `yaml:"failureCooldownMinutes"`
 	MaxConcurrentReconciles *int                 `yaml:"maxConcurrentReconciles"`
 	RegistryCredentials     []RegistryCredential `yaml:"registryCredentials"`

--- a/manifests/k8s.yaml
+++ b/manifests/k8s.yaml
@@ -153,7 +153,7 @@ data:
     #   jobs: ["backup"]
     #   cronJobs: ["nightly"]
     #   pods: ["custom-pod"]
-    requestTimeout: 2m
+    requestTimeout: 120      # seconds; set to 0 to disable per-request deadlines
     # failureCooldownMinutes: 1440   # retry failed pushes after one day; set to 0 to disable the cooldown
     #ecr:
     #  accountID: "123456789012"


### PR DESCRIPTION
## Summary
- add an HTTP handler on the metrics server that resets mirror cooldowns on demand
- validate configured namespaces against the cluster, expanding wildcards and logging errors or warnings
- expose a reset method on the pusher and cover the new behaviours with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4548d509c8328a3e3039c99e3a724