### PR TITLE
Add support for DIGEST_PULL_IGNORED_TAGS to opt out digest-based pulls for specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Copycat is configured through a combination of environment variables and a YAML 
 **Mirroring behavior**
 
 - `DIGEST_PULL`: resolve tags to digests before pulling (`false` by default).
+- `DIGEST_PULL_IGNORED_TAGS`: comma-separated tags that should stay tag-based even when digest pull is enabled (`latest` by default).
 - `CHECK_NODE_PLATFORM`: consult node architecture/OS before mirroring multi-arch images (`false` by default, requires `get` on `nodes`).
 - `ALLOW_DIFFERENT_DIGEST_REPUSH`: permit overwriting tags with different digests (`true` by default, `latest` is always protected).
 - `DRY_RUN`: perform all operations except pushing to the target registry (`false` by default).
@@ -234,6 +235,8 @@ ecr:
       ]
     }
 digestPull: true                  # resolve source tags to their immutable digest before pulling
+digestPullIgnoredTags:            # optional: keep these tags tag-based even when digestPull is enabled
+  - latest
 checkNodePlatform: true           # optional: ask the API for node architecture/OS before mirroring Pod images
 mirrorPlatforms:                  # optional: always mirror these additional platforms when digestPull is enabled
   - amd64                         # shorthand for linux/amd64 also works

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -153,6 +153,7 @@ func main() {
 		cfg.RequestTimeout,
 		cfg.FailureCooldown,
 		cfg.DigestPull,
+		cfg.DigestPullIgnoredTags,
 		cfg.AllowDifferentDigestRepush,
 		cfg.ExcludedRegistries,
 		cfg.MirrorPlatforms,

--- a/cmd/manager/runtime_config.go
+++ b/cmd/manager/runtime_config.go
@@ -42,6 +42,7 @@ type runtimeConfig struct {
 	Keychain                   authn.Keychain
 	FailureCooldown            time.Duration
 	DigestPull                 bool
+	DigestPullIgnoredTags      []string
 	CheckNodePlatform          bool
 	MirrorPlatforms            []string
 	AllowDifferentDigestRepush bool
@@ -221,6 +222,10 @@ func loadRuntimeConfig(ctx context.Context, dryRunFlag, dryPullFlag bool, fileCf
 		}
 		digestPull = parsed
 	}
+	digestPullIgnoredTags := resolveList(os.Getenv("DIGEST_PULL_IGNORED_TAGS"), fileCfg.DigestPullIgnoredTags)
+	if len(digestPullIgnoredTags) == 0 {
+		digestPullIgnoredTags = []string{"latest"}
+	}
 
 	checkNodePlatform := fileCfg.CheckNodePlatform
 	if v := strings.TrimSpace(os.Getenv("CHECK_NODE_PLATFORM")); v != "" {
@@ -288,6 +293,7 @@ func loadRuntimeConfig(ctx context.Context, dryRunFlag, dryPullFlag bool, fileCf
 		Keychain:                   keychain,
 		FailureCooldown:            failureCooldown,
 		DigestPull:                 digestPull,
+		DigestPullIgnoredTags:      digestPullIgnoredTags,
 		CheckNodePlatform:          checkNodePlatform,
 		MirrorPlatforms:            mirrorPlatforms,
 		AllowDifferentDigestRepush: allowDifferentDigestRepush,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	ECR                        ECR                  `yaml:"ecr"`
 	Docker                     Docker               `yaml:"docker"`
 	DigestPull                 bool                 `yaml:"digestPull"`
+	DigestPullIgnoredTags      []string             `yaml:"digestPullIgnoredTags"`
 	CheckNodePlatform          bool                 `yaml:"checkNodePlatform"`
 	MirrorPlatforms            []string             `yaml:"mirrorPlatforms"`
 	AllowDifferentDigestRepush *bool                `yaml:"allowDifferentDigestRepush"`

--- a/internal/mirror/pusher.go
+++ b/internal/mirror/pusher.go
@@ -215,6 +215,7 @@ type pusher struct {
 	dryPull                    bool
 	transform                  func(string) string
 	pullByDigest               bool
+	digestPullIgnoredTags      map[string]struct{}
 	allowDifferentDigestRepush bool
 	mirrorPlatforms            []platformSpec
 	mirrorPlatformSet          map[string]struct{}
@@ -254,7 +255,7 @@ func (e *RetryError) Unwrap() error {
 	return e.Cause
 }
 
-func NewPusher(t registry.Target, dryRun bool, dryPull bool, transform func(string) string, logger logr.Logger, keychain authn.Keychain, requestTimeout time.Duration, failureCooldown time.Duration, pullByDigest bool, allowDifferentDigestRepush bool, excluded []string, mirrorPlatforms []string) Pusher {
+func NewPusher(t registry.Target, dryRun bool, dryPull bool, transform func(string) string, logger logr.Logger, keychain authn.Keychain, requestTimeout time.Duration, failureCooldown time.Duration, pullByDigest bool, digestPullIgnoredTags []string, allowDifferentDigestRepush bool, excluded []string, mirrorPlatforms []string) Pusher {
 	if transform == nil {
 		transform = util.CleanRepoName
 	}
@@ -285,6 +286,7 @@ func NewPusher(t registry.Target, dryRun bool, dryPull bool, transform func(stri
 		dryPull:                    dryPull,
 		transform:                  transform,
 		pullByDigest:               pullByDigest,
+		digestPullIgnoredTags:      normalizeTagSet(digestPullIgnoredTags),
 		allowDifferentDigestRepush: allowDifferentDigestRepush,
 		mirrorPlatforms:            parsedPlatforms,
 		mirrorPlatformSet:          platformSet,
@@ -299,6 +301,18 @@ func NewPusher(t registry.Target, dryRun bool, dryPull bool, transform func(stri
 		now:                        time.Now,
 		excludedRegistries:         normalizedExclusions,
 	}
+}
+
+func normalizeTagSet(tags []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		trimmed := strings.ToLower(strings.TrimSpace(tag))
+		if trimmed == "" {
+			continue
+		}
+		out[trimmed] = struct{}{}
+	}
+	return out
 }
 
 func newTransport(insecure bool) http.RoundTripper {
@@ -413,14 +427,24 @@ func (p *pusher) Mirror(ctx context.Context, src string, meta Metadata) error {
 	}
 
 	normalizedID := normalizeImageID(meta.ImageID)
-	pullRef, podDigestStr, havePodDigest, pullRefErr := pullReferenceFromMetadata(p.pullByDigest, normalizedID, srcRef)
+	usePodDigest := p.pullByDigest
+	if p.pullByDigest {
+		if srcTag, ok := srcRef.(name.Tag); ok {
+			if _, ignored := p.digestPullIgnoredTags[strings.ToLower(strings.TrimSpace(srcTag.TagStr()))]; ignored {
+				usePodDigest = false
+				log.V(1).Info("digest pull ignored for tag configured in digestPullIgnoredTags", "tag", srcTag.TagStr())
+			}
+		}
+	}
+
+	pullRef, podDigestStr, havePodDigest, pullRefErr := pullReferenceFromMetadata(usePodDigest, normalizedID, srcRef)
 	if pullRefErr != nil {
 		log.V(1).Error(pullRefErr, "failed to parse digest from pod imageID", "imageID", normalizedID)
 	} else if havePodDigest {
 		log.V(1).Info("using pod imageID digest for pull", "imageID", normalizedID)
 	}
 
-	if p.pullByDigest && !havePodDigest && !sourceIsDigest {
+	if usePodDigest && !havePodDigest && !sourceIsDigest {
 		procLog.V(1).Info(
 			"digest pull enabled but pod imageID digest is not available yet, skipping until it is reported",
 			"result", "skipped",
@@ -465,7 +489,7 @@ func (p *pusher) Mirror(ctx context.Context, src string, meta Metadata) error {
 		requestPlatform = nil
 	}
 
-	if p.pullByDigest && havePodDigest {
+	if usePodDigest && havePodDigest {
 		var digestRef name.Reference
 		if existingDigest, ok := targetRef.(name.Digest); ok && strings.EqualFold(existingDigest.DigestStr(), podDigestStr) {
 			digestRef = existingDigest
@@ -518,7 +542,7 @@ func (p *pusher) Mirror(ctx context.Context, src string, meta Metadata) error {
 		descCancel context.CancelFunc
 	)
 
-	if p.pullByDigest && !havePodDigest && len(p.mirrorPlatforms) == 0 {
+	if usePodDigest && !havePodDigest && len(p.mirrorPlatforms) == 0 {
 		headCtx, cancelHead := p.operationContext(ctx)
 		targetHead, headErr := remoteHeadFunc(
 			targetRef,
@@ -578,6 +602,9 @@ func (p *pusher) Mirror(ctx context.Context, src string, meta Metadata) error {
 	if err != nil {
 		logRegistryAuthError(log, err, "pull descriptor")
 		metrics.RecordPullError(src)
+		if usePodDigest && havePodDigest && strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+			return p.failureResult(target, fmt.Errorf("describe %s: %w (looks like the original image was overwritten and pod imageID digest is no longer available at source)", src, err))
+		}
 		return p.failureResult(target, fmt.Errorf("describe %s: %w", src, err))
 	}
 	defer descCancel()

--- a/internal/mirror/pusher_test.go
+++ b/internal/mirror/pusher_test.go
@@ -202,7 +202,7 @@ func TestResolveRepoPathWithRegistryMetadata(t *testing.T) {
 }
 
 func TestDryPullOption(t *testing.T) {
-	p := NewPusher(fakeTarget{}, true, true, nil, testr.New(t), nil, 0, 0, false, true, nil, nil)
+	p := NewPusher(fakeTarget{}, true, true, nil, testr.New(t), nil, 0, 0, false, nil, true, nil, nil)
 
 	if !p.DryPull() {
 		t.Fatalf("expected dry pull to be enabled")
@@ -210,7 +210,7 @@ func TestDryPullOption(t *testing.T) {
 }
 
 func TestNewPusherConfiguresExcludedRegistries(t *testing.T) {
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, true, []string{"registry.gitlab.com/team/"}, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, []string{"registry.gitlab.com/team/"}, nil)
 
 	impl, ok := p.(*pusher)
 	if !ok {
@@ -226,7 +226,7 @@ func TestNewPusherConfiguresExcludedRegistries(t *testing.T) {
 }
 
 func TestNewPusherNormalizesIndexDockerIO(t *testing.T) {
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, true, []string{"index.docker.io"}, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, []string{"index.docker.io"}, nil)
 
 	impl, ok := p.(*pusher)
 	if !ok {
@@ -249,7 +249,7 @@ func TestMirrorRecordsPullErrorMetric(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteGetFunc = original })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, nil, nil)
 	ctx := context.Background()
 
 	err := p.Mirror(ctx, "docker.io/library/nginx:latest", Metadata{})
@@ -296,7 +296,7 @@ func TestMirrorSkipsSourcePullWhenTargetDigestMatches(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteGetFunc = originalGet })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, true, nil, nil)
 	impl, ok := p.(*pusher)
 	if !ok {
 		t.Fatalf("expected *pusher, got %T", p)
@@ -340,7 +340,7 @@ func TestMirrorRechecksTargetAfterSuccessfulSkip(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteGetFunc = originalGet })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, true, nil, nil)
 	source := "docker.io/library/nginx@sha256:" + strings.Repeat("b", 64)
 
 	if err := p.Mirror(context.Background(), source, Metadata{}); err != nil {
@@ -388,7 +388,7 @@ func TestMirrorContinuesPullWhenTargetDigestUnknown(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteGetFunc = originalGet })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, true, nil, nil)
 
 	source := "docker.io/library/nginx@sha256:" + strings.Repeat("a", 64)
 
@@ -413,7 +413,7 @@ func TestMirrorRecordsPushErrorMetric(t *testing.T) {
 	metrics.Reset()
 	t.Cleanup(metrics.Reset)
 
-	p := NewPusher(authErrorTarget{fakeTarget: fakeTarget{}, err: errors.New("auth failed")}, false, false, nil, testr.New(t), nil, 0, 0, false, true, nil, nil)
+	p := NewPusher(authErrorTarget{fakeTarget: fakeTarget{}, err: errors.New("auth failed")}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, nil, nil)
 	ctx := context.Background()
 
 	err := p.Mirror(ctx, "docker.io/library/nginx:1.25", Metadata{})
@@ -427,8 +427,58 @@ func TestMirrorRecordsPushErrorMetric(t *testing.T) {
 	}
 }
 
+func TestMirrorDigestPullIgnoredTagSkipsPodImageIDDigest(t *testing.T) {
+	originalGet := remoteGetFunc
+	remoteGetFunc = func(ref name.Reference, _ ...remote.Option) (*remote.Descriptor, error) {
+		if got := ref.String(); got != "docker.io/library/nginx:latest" {
+			t.Fatalf("expected pull by tag for ignored tag, got %q", got)
+		}
+		return nil, errors.New("stop test")
+	}
+	t.Cleanup(func() { remoteGetFunc = originalGet })
+
+	originalHead := remoteHeadFunc
+	remoteHeadFunc = func(name.Reference, ...remote.Option) (*v1.Descriptor, error) {
+		return nil, &remotetransport.Error{StatusCode: http.StatusNotFound}
+	}
+	t.Cleanup(func() { remoteHeadFunc = originalHead })
+
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, []string{"latest"}, true, nil, nil)
+	err := p.Mirror(context.Background(), "docker.io/library/nginx:latest", Metadata{
+		ImageID: "docker.io/library/nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	if err == nil || !strings.Contains(err.Error(), "stop test") {
+		t.Fatalf("expected stop test error, got %v", err)
+	}
+}
+
+func TestMirrorManifestUnknownIncludesOverwriteHint(t *testing.T) {
+	originalGet := remoteGetFunc
+	remoteGetFunc = func(name.Reference, ...remote.Option) (*remote.Descriptor, error) {
+		return nil, errors.New("MANIFEST_UNKNOWN")
+	}
+	t.Cleanup(func() { remoteGetFunc = originalGet })
+
+	originalHead := remoteHeadFunc
+	remoteHeadFunc = func(name.Reference, ...remote.Option) (*v1.Descriptor, error) {
+		return nil, &remotetransport.Error{StatusCode: http.StatusNotFound}
+	}
+	t.Cleanup(func() { remoteHeadFunc = originalHead })
+
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, true, nil, nil)
+	err := p.Mirror(context.Background(), "docker.io/library/nginx:1.25", Metadata{
+		ImageID: "docker.io/library/nginx@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "original image was overwritten") {
+		t.Fatalf("expected overwrite hint in error, got %v", err)
+	}
+}
+
 func TestNewPusherSeparatesSourceAndTargetTransportSecurity(t *testing.T) {
-	p := NewPusher(fakeTarget{insecure: true}, false, false, nil, testr.New(t), nil, 0, 0, false, true, nil, nil)
+	p := NewPusher(fakeTarget{insecure: true}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, nil, nil)
 
 	impl, ok := p.(*pusher)
 	if !ok {
@@ -613,7 +663,7 @@ func TestMirrorPopulatesRegistryMetadataFromSource(t *testing.T) {
 				logMessages = append(logMessages, prefix+args)
 			}, funcr.Options{Verbosity: 10})
 
-			p := NewPusher(fakeTarget{prefix: "$registry/$namespace"}, false, false, nil, logger, nil, 0, 0, false, true, nil, nil)
+			p := NewPusher(fakeTarget{prefix: "$registry/$namespace"}, false, false, nil, logger, nil, 0, 0, false, nil, true, nil, nil)
 
 			_ = p.Mirror(context.Background(), tc.source, Metadata{Namespace: "default"})
 


### PR DESCRIPTION
### Motivation
- Provide a way to keep selected tags tag-based even when `digestPull` is enabled so ephemeral tags like `latest` aren’t resolved to pod digests and can still be pulled/pushed by tag.

### Description
- Add a new configuration field `DigestPullIgnoredTags` and environment variable `DIGEST_PULL_IGNORED_TAGS` (defaulting to `latest`) and document it in `README.md` and the sample YAML.
- Thread the new option through runtime configuration (`loadRuntimeConfig`), manager startup (`main.go`) and the mirror `pusher` constructor by adding a `digestPullIgnoredTags` parameter and storing a normalized set via `normalizeTagSet`.
- In `pusher.Mirror` honor the ignored-tag set by skipping pod-imageID digest resolution for matching source tags and log when an ignored tag forces tag-based pulls, and add an extra error hint when `MANIFEST_UNKNOWN` appears while using a pod digest.
- Update and add unit tests in `internal/mirror/pusher_test.go` to account for the new constructor parameter and to cover ignored-tag behavior and the manifest-overwrite hint.

### Testing
- Ran unit tests in the mirror package with `go test ./internal/mirror -run Test` which executed updated and new tests and they passed locally.
- Ran the repository test suite with `go test ./...` to ensure no regressions in other packages and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33d1b21dc8328a4f104094f062026)