### PR TITLE
Add `ignoreMissingPlatforms` option to suppress missing-platform logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,10 @@ ecr:
       ]
     }
 digestPull: true                  # resolve source tags to their immutable digest before pulling
-digestPullIgnoredTags:            # optional: keep these tags tag-based even when digestPull is enabled
+digestPullIgnoredTags:            # optional: keep these tags tag-based even when digestPull is enabled (default: ["latest"])
   - latest
+ignoreMissingPlatforms:           # optional: regex list for source|platform to suppress "does not offer platform" logs
+  - '^registry\\.gitlab\\.com/.+\\|linux/arm64$'
 checkNodePlatform: true           # optional: ask the API for node architecture/OS before mirroring Pod images
 mirrorPlatforms:                  # optional: always mirror these additional platforms when digestPull is enabled
   - amd64                         # shorthand for linux/amd64 also works

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -154,6 +154,7 @@ func main() {
 		cfg.FailureCooldown,
 		cfg.DigestPull,
 		cfg.DigestPullIgnoredTags,
+		cfg.IgnoreMissingPlatforms,
 		cfg.AllowDifferentDigestRepush,
 		cfg.ExcludedRegistries,
 		cfg.MirrorPlatforms,

--- a/cmd/manager/runtime_config.go
+++ b/cmd/manager/runtime_config.go
@@ -43,6 +43,7 @@ type runtimeConfig struct {
 	FailureCooldown            time.Duration
 	DigestPull                 bool
 	DigestPullIgnoredTags      []string
+	IgnoreMissingPlatforms     []string
 	CheckNodePlatform          bool
 	MirrorPlatforms            []string
 	AllowDifferentDigestRepush bool
@@ -226,6 +227,7 @@ func loadRuntimeConfig(ctx context.Context, dryRunFlag, dryPullFlag bool, fileCf
 	if len(digestPullIgnoredTags) == 0 {
 		digestPullIgnoredTags = []string{"latest"}
 	}
+	ignoreMissingPlatforms := resolveList(os.Getenv("IGNORE_MISSING_PLATFORMS"), fileCfg.IgnoreMissingPlatforms)
 
 	checkNodePlatform := fileCfg.CheckNodePlatform
 	if v := strings.TrimSpace(os.Getenv("CHECK_NODE_PLATFORM")); v != "" {
@@ -294,6 +296,7 @@ func loadRuntimeConfig(ctx context.Context, dryRunFlag, dryPullFlag bool, fileCf
 		FailureCooldown:            failureCooldown,
 		DigestPull:                 digestPull,
 		DigestPullIgnoredTags:      digestPullIgnoredTags,
+		IgnoreMissingPlatforms:     ignoreMissingPlatforms,
 		CheckNodePlatform:          checkNodePlatform,
 		MirrorPlatforms:            mirrorPlatforms,
 		AllowDifferentDigestRepush: allowDifferentDigestRepush,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	Docker                     Docker               `yaml:"docker"`
 	DigestPull                 bool                 `yaml:"digestPull"`
 	DigestPullIgnoredTags      []string             `yaml:"digestPullIgnoredTags"`
+	IgnoreMissingPlatforms     []string             `yaml:"ignoreMissingPlatforms"`
 	CheckNodePlatform          bool                 `yaml:"checkNodePlatform"`
 	MirrorPlatforms            []string             `yaml:"mirrorPlatforms"`
 	AllowDifferentDigestRepush *bool                `yaml:"allowDifferentDigestRepush"`

--- a/internal/mirror/pusher.go
+++ b/internal/mirror/pusher.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -216,6 +217,7 @@ type pusher struct {
 	transform                  func(string) string
 	pullByDigest               bool
 	digestPullIgnoredTags      map[string]struct{}
+	ignoreMissingPlatforms     []*regexp.Regexp
 	allowDifferentDigestRepush bool
 	mirrorPlatforms            []platformSpec
 	mirrorPlatformSet          map[string]struct{}
@@ -255,7 +257,7 @@ func (e *RetryError) Unwrap() error {
 	return e.Cause
 }
 
-func NewPusher(t registry.Target, dryRun bool, dryPull bool, transform func(string) string, logger logr.Logger, keychain authn.Keychain, requestTimeout time.Duration, failureCooldown time.Duration, pullByDigest bool, digestPullIgnoredTags []string, allowDifferentDigestRepush bool, excluded []string, mirrorPlatforms []string) Pusher {
+func NewPusher(t registry.Target, dryRun bool, dryPull bool, transform func(string) string, logger logr.Logger, keychain authn.Keychain, requestTimeout time.Duration, failureCooldown time.Duration, pullByDigest bool, digestPullIgnoredTags []string, ignoreMissingPlatforms []string, allowDifferentDigestRepush bool, excluded []string, mirrorPlatforms []string) Pusher {
 	if transform == nil {
 		transform = util.CleanRepoName
 	}
@@ -275,6 +277,7 @@ func NewPusher(t registry.Target, dryRun bool, dryPull bool, transform func(stri
 	}
 	normalizedExclusions := normalizeExcludedRegistries(excluded)
 	parsedPlatforms, platformSet := parseMirrorPlatforms(logger, mirrorPlatforms)
+	ignoreMissingPlatformRegex := compileRegexList(logger, "ignoreMissingPlatforms", ignoreMissingPlatforms)
 	targetInsecure := false
 	if t != nil {
 		targetInsecure = t.Insecure()
@@ -287,6 +290,7 @@ func NewPusher(t registry.Target, dryRun bool, dryPull bool, transform func(stri
 		transform:                  transform,
 		pullByDigest:               pullByDigest,
 		digestPullIgnoredTags:      normalizeTagSet(digestPullIgnoredTags),
+		ignoreMissingPlatforms:     ignoreMissingPlatformRegex,
 		allowDifferentDigestRepush: allowDifferentDigestRepush,
 		mirrorPlatforms:            parsedPlatforms,
 		mirrorPlatformSet:          platformSet,
@@ -311,6 +315,26 @@ func normalizeTagSet(tags []string) map[string]struct{} {
 			continue
 		}
 		out[trimmed] = struct{}{}
+	}
+	return out
+}
+
+func compileRegexList(logger logr.Logger, field string, patterns []string) []*regexp.Regexp {
+	if len(patterns) == 0 {
+		return nil
+	}
+	out := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		trimmed := strings.TrimSpace(pattern)
+		if trimmed == "" {
+			continue
+		}
+		compiled, err := regexp.Compile(trimmed)
+		if err != nil {
+			logger.Error(err, "invalid regex ignored", "field", field, "pattern", trimmed)
+			continue
+		}
+		out = append(out, compiled)
 	}
 	return out
 }
@@ -631,7 +655,7 @@ func (p *pusher) Mirror(ctx context.Context, src string, meta Metadata) error {
 	)
 
 	if len(p.mirrorPlatforms) > 0 && len(desiredPlatforms) > 1 && !desc.MediaType.IsIndex() {
-		logUnavailablePlatforms(log, src, desiredPlatforms[1:])
+		logUnavailablePlatforms(log, src, desiredPlatforms[1:], p.ignoreMissingPlatforms)
 	}
 
 	switch {
@@ -656,10 +680,12 @@ func (p *pusher) Mirror(ctx context.Context, src string, meta Metadata) error {
 		} else {
 			idx = filtered
 			if len(missing) > 0 {
-				logUnavailablePlatforms(log, src, missing)
-				log.Info(
-					"some configured mirrorPlatforms missing from source index", "missingPlatforms", specsToStrings(missing),
-				)
+				loggedMissing := logUnavailablePlatforms(log, src, missing, p.ignoreMissingPlatforms)
+				if len(loggedMissing) > 0 {
+					log.Info(
+						"some configured mirrorPlatforms missing from source index", "missingPlatforms", specsToStrings(loggedMissing),
+					)
+				}
 			}
 			log.V(1).Info(
 				"mirroring configured subset of multi-architecture index",
@@ -1403,11 +1429,12 @@ func specsToStrings(specs []platformSpec) []string {
 	return out
 }
 
-func logUnavailablePlatforms(logger logr.Logger, src string, specs []platformSpec) {
+func logUnavailablePlatforms(logger logr.Logger, src string, specs []platformSpec, ignored []*regexp.Regexp) []platformSpec {
 	if len(specs) == 0 {
-		return
+		return nil
 	}
 	seen := make(map[string]struct{}, len(specs))
+	logged := make([]platformSpec, 0, len(specs))
 	for _, spec := range specs {
 		platform := spec.String()
 		if platform == "" {
@@ -1416,12 +1443,31 @@ func logUnavailablePlatforms(logger logr.Logger, src string, specs []platformSpe
 		if _, alreadyLogged := seen[platform]; alreadyLogged {
 			continue
 		}
+		if ignoreMissingPlatformLog(src, platform, ignored) {
+			seen[platform] = struct{}{}
+			continue
+		}
+		logged = append(logged, spec)
 		logger.Info(
 			fmt.Sprintf("image %s does not offer platform %s", src, platform),
 			"platform", platform,
 		)
 		seen[platform] = struct{}{}
 	}
+	return logged
+}
+
+func ignoreMissingPlatformLog(src, platform string, ignored []*regexp.Regexp) bool {
+	if len(ignored) == 0 {
+		return false
+	}
+	candidate := src + "|" + platform
+	for _, pattern := range ignored {
+		if pattern.MatchString(candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func shouldMirrorEntireIndex(mediaType types.MediaType, pullByDigest bool, platform *v1.Platform) bool {

--- a/internal/mirror/pusher_test.go
+++ b/internal/mirror/pusher_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -202,7 +203,7 @@ func TestResolveRepoPathWithRegistryMetadata(t *testing.T) {
 }
 
 func TestDryPullOption(t *testing.T) {
-	p := NewPusher(fakeTarget{}, true, true, nil, testr.New(t), nil, 0, 0, false, nil, true, nil, nil)
+	p := NewPusher(fakeTarget{}, true, true, nil, testr.New(t), nil, 0, 0, false, nil, nil, true, nil, nil)
 
 	if !p.DryPull() {
 		t.Fatalf("expected dry pull to be enabled")
@@ -210,7 +211,7 @@ func TestDryPullOption(t *testing.T) {
 }
 
 func TestNewPusherConfiguresExcludedRegistries(t *testing.T) {
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, []string{"registry.gitlab.com/team/"}, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, nil, true, []string{"registry.gitlab.com/team/"}, nil)
 
 	impl, ok := p.(*pusher)
 	if !ok {
@@ -226,7 +227,7 @@ func TestNewPusherConfiguresExcludedRegistries(t *testing.T) {
 }
 
 func TestNewPusherNormalizesIndexDockerIO(t *testing.T) {
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, []string{"index.docker.io"}, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, nil, true, []string{"index.docker.io"}, nil)
 
 	impl, ok := p.(*pusher)
 	if !ok {
@@ -249,7 +250,7 @@ func TestMirrorRecordsPullErrorMetric(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteGetFunc = original })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, nil, true, nil, nil)
 	ctx := context.Background()
 
 	err := p.Mirror(ctx, "docker.io/library/nginx:latest", Metadata{})
@@ -296,7 +297,7 @@ func TestMirrorSkipsSourcePullWhenTargetDigestMatches(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteGetFunc = originalGet })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, nil, true, nil, nil)
 	impl, ok := p.(*pusher)
 	if !ok {
 		t.Fatalf("expected *pusher, got %T", p)
@@ -340,7 +341,7 @@ func TestMirrorRechecksTargetAfterSuccessfulSkip(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteGetFunc = originalGet })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, nil, true, nil, nil)
 	source := "docker.io/library/nginx@sha256:" + strings.Repeat("b", 64)
 
 	if err := p.Mirror(context.Background(), source, Metadata{}); err != nil {
@@ -388,7 +389,7 @@ func TestMirrorContinuesPullWhenTargetDigestUnknown(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteGetFunc = originalGet })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, nil, true, nil, nil)
 
 	source := "docker.io/library/nginx@sha256:" + strings.Repeat("a", 64)
 
@@ -413,7 +414,7 @@ func TestMirrorRecordsPushErrorMetric(t *testing.T) {
 	metrics.Reset()
 	t.Cleanup(metrics.Reset)
 
-	p := NewPusher(authErrorTarget{fakeTarget: fakeTarget{}, err: errors.New("auth failed")}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, nil, nil)
+	p := NewPusher(authErrorTarget{fakeTarget: fakeTarget{}, err: errors.New("auth failed")}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, nil, true, nil, nil)
 	ctx := context.Background()
 
 	err := p.Mirror(ctx, "docker.io/library/nginx:1.25", Metadata{})
@@ -443,7 +444,7 @@ func TestMirrorDigestPullIgnoredTagSkipsPodImageIDDigest(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteHeadFunc = originalHead })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, []string{"latest"}, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, []string{"latest"}, nil, true, nil, nil)
 	err := p.Mirror(context.Background(), "docker.io/library/nginx:latest", Metadata{
 		ImageID: "docker.io/library/nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	})
@@ -465,7 +466,7 @@ func TestMirrorManifestUnknownIncludesOverwriteHint(t *testing.T) {
 	}
 	t.Cleanup(func() { remoteHeadFunc = originalHead })
 
-	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, true, nil, nil)
+	p := NewPusher(fakeTarget{}, false, false, nil, testr.New(t), nil, 0, 0, true, nil, nil, true, nil, nil)
 	err := p.Mirror(context.Background(), "docker.io/library/nginx:1.25", Metadata{
 		ImageID: "docker.io/library/nginx@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 	})
@@ -478,7 +479,7 @@ func TestMirrorManifestUnknownIncludesOverwriteHint(t *testing.T) {
 }
 
 func TestNewPusherSeparatesSourceAndTargetTransportSecurity(t *testing.T) {
-	p := NewPusher(fakeTarget{insecure: true}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, true, nil, nil)
+	p := NewPusher(fakeTarget{insecure: true}, false, false, nil, testr.New(t), nil, 0, 0, false, nil, nil, true, nil, nil)
 
 	impl, ok := p.(*pusher)
 	if !ok {
@@ -663,7 +664,7 @@ func TestMirrorPopulatesRegistryMetadataFromSource(t *testing.T) {
 				logMessages = append(logMessages, prefix+args)
 			}, funcr.Options{Verbosity: 10})
 
-			p := NewPusher(fakeTarget{prefix: "$registry/$namespace"}, false, false, nil, logger, nil, 0, 0, false, nil, true, nil, nil)
+			p := NewPusher(fakeTarget{prefix: "$registry/$namespace"}, false, false, nil, logger, nil, 0, 0, false, nil, nil, true, nil, nil)
 
 			_ = p.Mirror(context.Background(), tc.source, Metadata{Namespace: "default"})
 
@@ -1124,5 +1125,15 @@ func TestDetectRegistryAuthErrorByDiagnostic(t *testing.T) {
 	want := "UNAUTHORIZED: authentication required"
 	if info.diagnostics[0] != want {
 		t.Fatalf("unexpected diagnostic: %q", info.diagnostics[0])
+	}
+}
+
+func TestIgnoreMissingPlatformLog(t *testing.T) {
+	patterns := []*regexp.Regexp{regexp.MustCompile(`^registry\.gitlab\.com/.+\|linux/arm64$`)}
+	if !ignoreMissingPlatformLog("registry.gitlab.com/org/app:1.0.0", "linux/arm64", patterns) {
+		t.Fatalf("expected ignore match")
+	}
+	if ignoreMissingPlatformLog("registry.gitlab.com/org/app:1.0.0", "linux/amd64", patterns) {
+		t.Fatalf("did not expect ignore match for different platform")
 	}
 }

--- a/manifests/k8s.yaml
+++ b/manifests/k8s.yaml
@@ -152,10 +152,13 @@ data:
     dryPull: true                       # log source pulls without contacting upstream registries
     includeNamespaces: ["test"]
     # digestPull: true                  # resolve source tags to their immutable digest before pulling
+    # digestPullIgnoredTags: ["latest"] # optional: defaults to ["latest"] when omitted
     # checkNodePlatform: true           # optional: ask the API for node architecture/OS before mirroring Pod images
     # mirrorPlatforms:                  # optional: always mirror these additional platforms when digestPull is enabled
     # - amd64                           # shorthand for linux/amd64 also works
     # - linux/arm64
+    # ignoreMissingPlatforms:           # optional: regex list matching "<source>|<platform>" to suppress missing-platform info logs
+    # - '^registry\\.gitlab\\.com/.+\\|linux/arm64$'
     # allowDifferentDigestRepush: false # optional: fail when the target tag already exists with a different digest (except for "latest")
     # excludeRegistries: ["123456789.dkr.ecr.eu-central-1.amazonaws.com", "registry.gitlab.com", "internal.registry/team", "docker.io"]
     # watchResources:


### PR DESCRIPTION
### Motivation
- Provide a way to suppress noisy "image does not offer platform" logs for known source/platform combinations by matching `<source>|<platform>` with regexes.
- Allow configuration via the config file and `IGNORE_MISSING_PLATFORMS` environment variable so operators can silence expected missing-platform warnings.

### Description
- Add a new config field `IgnoreMissingPlatforms` (`[]string`) to `internal/config.Config` and document the option in `README.md` and `manifests/k8s.yaml`.
- Wire the runtime parsing of `IGNORE_MISSING_PLATFORMS` into `runtimeConfig` and pass `cfg.IgnoreMissingPlatforms` into the pusher in `cmd/manager/main.go`.
- Extend the pusher to accept `ignoreMissingPlatforms` patterns, compile them to `*regexp.Regexp` via `compileRegexList`, and store them on the `pusher` implementation.
- Filter missing-platform log entries by calling `ignoreMissingPlatformLog` from `logUnavailablePlatforms`, and only emit info logs for platforms not matched by any configured regex; `logUnavailablePlatforms` now returns the subset that was actually logged.
- Update `internal/mirror/pusher_test.go` to accommodate the new `NewPusher` parameter and add `TestIgnoreMissingPlatformLog` to verify regex-based suppression.

### Testing
- Ran unit tests with `go test ./...` and all tests succeeded, including the newly added `TestIgnoreMissingPlatformLog` in `internal/mirror/pusher_test.go`.
- Existing pusher unit tests were updated to match the new `NewPusher` signature and continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5795ca688328b2b38c9a19e35e20)