### PR TITLE
Update README intro and remove WIP disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 ![k8s-copycat logo](k8s-copycat-logo.png)
 
-> Continuously mirror the images your Kubernetes workloads already run into the registry you control.
-
-## ⚠️ Disclaimer
-
-This is an **absolutely experimental WIP project**. Do **not** use it in production environments.
+> Your cluster’s insurance policy: A non-invasive controller that preserves and replicates every container image your workloads need to a registry you control.
 
 ## Table of Contents
 


### PR DESCRIPTION
### Motivation
- Improve the project README messaging by replacing the terse tagline and experimental disclaimer with a clearer value proposition that explains what the controller does.

### Description
- Update the opening paragraph in `README.md` to a more descriptive lead: "Your cluster’s insurance policy..." and remove the previous `⚠️ Disclaimer` section and the older terse tagline.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4421cb40832891acf8f6553f18cd)