### PR TITLE
ci: add fmt, lint, and conventional commit workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,65 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  golangci-lint:
+    name: Format and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Check gofmt
+        run: |
+          unformatted="$(gofmt -l cmd internal pkg)"
+          if [ -n "${unformatted}" ]; then
+            echo "The following files are not gofmt-compliant:"
+            echo "${unformatted}"
+            echo "Run 'gofmt -w cmd internal pkg' to fix."
+            exit 1
+          fi
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+
+  commit-check:
+    name: Conventional commits
+    # Only meaningful on PRs (needs a merge base + PR head sha). Dependabot
+    # already emits Conventional Commit messages and runs with a restricted
+    # token, so skip the check on its PRs to avoid false failures.
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: commit-check/commit-check-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: true
+          branch: true
+          author-name: true
+          author-email: true
+          commit-signoff: false
+          merge-base: true
+          imperative: false
+          job-summary: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 
 run:
   timeout: 5m
@@ -15,4 +15,3 @@ linters:
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0
-  exclude-use-default: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,29 +43,29 @@ type RegistryCredential struct {
 }
 
 type Config struct {
-	TargetKind                 string               `yaml:"targetKind"` // ecr | docker
-	LogLevel                   string               `yaml:"logLevel"`
-	ECR                        ECR                  `yaml:"ecr"`
-	Docker                     Docker               `yaml:"docker"`
-	DigestPull                 bool                 `yaml:"digestPull"`
-	DigestPullIgnoredTags      []string             `yaml:"digestPullIgnoredTags"`
-	IgnoreMissingPlatforms     []string             `yaml:"ignoreMissingPlatforms"`
-	CheckNodePlatform          bool                 `yaml:"checkNodePlatform"`
-	MirrorPlatforms            []string             `yaml:"mirrorPlatforms"`
-	AllowDifferentDigestRepush *bool                `yaml:"allowDifferentDigestRepush"`
-	IncludeNamespaces          []string             `yaml:"includeNamespaces"`
-	SkipNamespaces             []string             `yaml:"skipNamespaces"`
-	SkipNames                  ResourceSkipNames    `yaml:"skipNames"`
-	ExcludeRegistries          []string             `yaml:"excludeRegistries"`
-	WatchResources             []string             `yaml:"watchResources"`
-	DryRun                     bool                 `yaml:"dryRun"`
-	DryPull                    bool                 `yaml:"dryPull"`
-	RequestTimeoutSeconds       *int                `yaml:"requestTimeout"`
-	RegistryRetryAttempts       *int                `yaml:"registryRetryAttempts"`
-	RegistryRetryBackoffSeconds *int                `yaml:"registryRetryBackoff"`
-	FailureCooldownMinutes      *int                `yaml:"failureCooldownMinutes"`
-	ForceReconcileMinutes       *int                `yaml:"forceReconcileMinutes"`
-	MaxConcurrentReconciles     *int                `yaml:"maxConcurrentReconciles"`
+	TargetKind                  string               `yaml:"targetKind"` // ecr | docker
+	LogLevel                    string               `yaml:"logLevel"`
+	ECR                         ECR                  `yaml:"ecr"`
+	Docker                      Docker               `yaml:"docker"`
+	DigestPull                  bool                 `yaml:"digestPull"`
+	DigestPullIgnoredTags       []string             `yaml:"digestPullIgnoredTags"`
+	IgnoreMissingPlatforms      []string             `yaml:"ignoreMissingPlatforms"`
+	CheckNodePlatform           bool                 `yaml:"checkNodePlatform"`
+	MirrorPlatforms             []string             `yaml:"mirrorPlatforms"`
+	AllowDifferentDigestRepush  *bool                `yaml:"allowDifferentDigestRepush"`
+	IncludeNamespaces           []string             `yaml:"includeNamespaces"`
+	SkipNamespaces              []string             `yaml:"skipNamespaces"`
+	SkipNames                   ResourceSkipNames    `yaml:"skipNames"`
+	ExcludeRegistries           []string             `yaml:"excludeRegistries"`
+	WatchResources              []string             `yaml:"watchResources"`
+	DryRun                      bool                 `yaml:"dryRun"`
+	DryPull                     bool                 `yaml:"dryPull"`
+	RequestTimeoutSeconds       *int                 `yaml:"requestTimeout"`
+	RegistryRetryAttempts       *int                 `yaml:"registryRetryAttempts"`
+	RegistryRetryBackoffSeconds *int                 `yaml:"registryRetryBackoff"`
+	FailureCooldownMinutes      *int                 `yaml:"failureCooldownMinutes"`
+	ForceReconcileMinutes       *int                 `yaml:"forceReconcileMinutes"`
+	MaxConcurrentReconciles     *int                 `yaml:"maxConcurrentReconciles"`
 	RegistryCredentials         []RegistryCredential `yaml:"registryCredentials"`
 	PathMap                     []util.PathMapping   `yaml:"pathMap"`
 }

--- a/internal/mirror/pusher.go
+++ b/internal/mirror/pusher.go
@@ -1717,10 +1717,6 @@ func normalizeImageReference(val string) string {
 	// Detect by checking whether the first path component contains a dot or colon.
 	if firstSlash := strings.IndexByte(trimmed, '/'); firstSlash == -1 {
 		// Single-name image like "nginx:latest" → "docker.io/library/nginx:latest"
-		name := trimmed
-		if idx := strings.IndexAny(name, ":@"); idx != -1 {
-			name = name[:idx]
-		}
 		trimmed = "docker.io/library/" + trimmed
 	} else {
 		firstComponent := trimmed[:firstSlash]

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,14 +71,12 @@ func registryLabel(image string) string {
 	trimmed = strings.TrimPrefix(trimmed, "https://")
 	trimmed = strings.TrimPrefix(trimmed, "http://")
 
-	first := trimmed
-	if idx := strings.Index(trimmed, "/"); idx >= 0 {
-		first = trimmed[:idx]
-	} else {
+	idx := strings.Index(trimmed, "/")
+	if idx < 0 {
 		return "docker.io"
 	}
 
-	first = strings.TrimSpace(first)
+	first := strings.TrimSpace(trimmed[:idx])
 	if first == "" {
 		return ""
 	}


### PR DESCRIPTION
Adds a Lint workflow that runs gofmt and golangci-lint on PRs/pushes to main and validates Conventional Commit messages on PRs. The commit check is skipped for Dependabot PRs, which already emit conforming messages and run with a restricted token.

Also applies gofmt to internal/config/config.go so the new fmt check passes.

Implements the ideas from #19 (superseding the outdated main.go changes and typo on that branch, and the invalid De Morgan rewrite already fixed on main).

Closes #19